### PR TITLE
The search method for get_sanctioned_info is not optimal

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,9 @@ Revision history for Data-Validate-Sanctions
 {{$NEXT}}
         last_updated will now return the timestamp of the latest list that was updated if no argument is provided
 
+0.12  2016-11-15 11:44:58 CST
+        - Improving the search for larger sanction lists
+
 0.11      2018-07-11 14:40:36+08:00 Asia/Manila
         Update cached list only on update any of the lists. Handle network errors.
         Use YAML to store cached lists, to have some metadata. Store this file in `share` by default.

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -62,7 +62,7 @@ my %WriteMakefileArgs = (
     "Test::Warn" => "0.23",
     "Test::Warnings" => "0.026"
   },
-  "VERSION" => "0.11",
+  "VERSION" => "0.12",
   "test" => {
     "TESTS" => "t/*.t"
   }

--- a/lib/Data/Validate/Sanctions.pm
+++ b/lib/Data/Validate/Sanctions.pm
@@ -220,7 +220,7 @@ sub get_sanctioned_info {    ## no critic (RequireArgUnpacking)
         push(@sanctioned_names,  keys %{$self->{_token_sanctioned_names}->{$token}});
     }
 
-    foreach my $sanctioned_name (@sanctioned_names) {
+    foreach my $sanctioned_name (sort @sanctioned_names) {
         my $sanctioned_name_tokens =$self->{_sanctioned_name_tokens}->{$sanctioned_name};
         next unless _name_matches(\@client_name_tokens, $sanctioned_name_tokens);
 

--- a/lib/Data/Validate/Sanctions.pm
+++ b/lib/Data/Validate/Sanctions.pm
@@ -19,7 +19,7 @@ use List::Util qw(any uniq max min);
 use Locale::Country;
 use Text::Trim qw(trim);
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 
 my $sanction_file = _default_sanction_file();
 my $instance;

--- a/lib/Data/Validate/Sanctions.pm
+++ b/lib/Data/Validate/Sanctions.pm
@@ -296,8 +296,7 @@ sub _load_data {
     }
     $self->_index_data();
 
-    my %index = $self->{_index}->%*;
-    foreach my $sanctioned_name (keys %index) {
+    foreach my $sanctioned_name (keys $self->{_index}->%*) {
         my @tokens = _clean_names($sanctioned_name);
         $self->{_sanctioned_name_tokens}->{$sanctioned_name} = \@tokens;
         foreach my $token (@tokens){

--- a/lib/Data/Validate/Sanctions.pm
+++ b/lib/Data/Validate/Sanctions.pm
@@ -215,12 +215,16 @@ sub get_sanctioned_info {    ## no critic (RequireArgUnpacking)
 
     my @match_with_dob_text;
 
-    my @sanctioned_names = ();
+    # only pick the sanctioned names which have common token with the client tokens
+    # and deduplicate the list
+    my $filtered_sanctioned_names = {};
     foreach my $token (@client_name_tokens) {
-        push(@sanctioned_names,  keys %{$self->{_token_sanctioned_names}->{$token}});
+        foreach my $name ( keys %{$self->{_token_sanctioned_names}->{$token}}) {
+            $filtered_sanctioned_names->{$name} = 1;
+        }
     }
 
-    foreach my $sanctioned_name (sort @sanctioned_names) {
+    foreach my $sanctioned_name (sort keys %{$filtered_sanctioned_names}) {
         my $sanctioned_name_tokens =$self->{_sanctioned_name_tokens}->{$sanctioned_name};
         next unless _name_matches(\@client_name_tokens, $sanctioned_name_tokens);
 


### PR DESCRIPTION
The search method for get_sanctioned_info_speed is not optimal, especially for larger sanction lists.

This change will sacrifice a bit of space to gain better performance.

We were going through all the sanction lists for every client. That changed to only names which have at least one common token with the client.
And we were tokenizing the static sanctions list for every single client. Now that only happens during data initialization (_load_data).
